### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Embedding-related repos from CodeFuse, including:
 
 **Star History**
 
-[![Star History Chart](https://api.star-history.com/svg?repos=codefuse-ai/CodeFuse-Embeddings&type=date&legend=top-left)](https://www.star-history.com/#codefuse-ai/CodeFuse-Embeddings&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=codefuse-ai/CodeFuse-Embeddings&type=date&legend=top-left)](https://star-history.dera.page/#codefuse-ai/CodeFuse-Embeddings&type=date&legend=top-left)


### PR DESCRIPTION
The Star History chart in the README is broken, as the current provider can no longer fetch stargazer data reliably under GitHub's API restrictions. This updates the chart to use a working alternative that needs no API token, so the chart renders correctly again.